### PR TITLE
Fix: Stream methods

### DIFF
--- a/m2x/v2/streams.py
+++ b/m2x/v2/streams.py
@@ -11,6 +11,10 @@ class Stream(Resource):
         self.device = device
         super(Stream, self).__init__(api, **data)
 
+    def update(self, **attrs):
+        self.data.update(self.item_update(self.api, self.device, self.name, **attrs))
+        return self.data
+
     def values(self, **params):
         return self.api.get(self.subpath('/values'), params=params)
 

--- a/m2x/v2/streams.py
+++ b/m2x/v2/streams.py
@@ -15,6 +15,9 @@ class Stream(Resource):
         self.data.update(self.item_update(self.api, self.device, self.name, **attrs))
         return self.data
 
+    def remove(self):
+        return self.api.delete(self.subpath(""))
+
     def values(self, **params):
         return self.api.get(self.subpath('/values'), params=params)
 


### PR DESCRIPTION
Streams don't have an `id` attribute, therefore the call to `item_update` that is being made [here](https://github.com/attm2x/m2x-python/blob/master/m2x/v2/resource.py#L16) doesn't work.

This PR fixes the issue by defining the `update` and `delete` methods on `Stream`