### PR TITLE
Fix: Update Collection.devices() to accept Params

### DIFF
--- a/m2x/v2/collections.py
+++ b/m2x/v2/collections.py
@@ -14,8 +14,8 @@ class Collection(Resource, Metadata):
     ITEM_PATH = 'collections/{id}'
     ITEMS_KEY = 'collections'
 
-    def devices(self):
-        return CollectionDevice.list(self.api, collection_id=self.id)
+    def devices(self, **params):
+        return CollectionDevice.list(self.api, collection_id=self.id, **params)
 
     def add_device(self, device_id):
         path = self.subpath('/devices/{device_id}'.format(device_id=device_id))


### PR DESCRIPTION
Collections.devices() which makes a call to [List Devices from an existing Collection](https://m2x.att.com/developer/documentation/v2/collections#List-Devices-from-an-existing-Collection) should accept parameters in the method signature, as this endpoint supports a number of parameters.