### PR TITLE
Update device search to use GET endpoint, send JSON body if data is set

### DIFF
--- a/examples/search_devices.py
+++ b/examples/search_devices.py
@@ -7,20 +7,24 @@ import os
 
 from m2x.client import M2XClient
 from m2x.v2.devices import Device
- 
+
 client = M2XClient(key=os.environ['API_KEY'])
 
 params = {
-	"visibility": "private",
-	"status": "enabled",
-	"limit": "3"
+    "visibility": "private",
+    "status": "enabled",
+    "limit": "3"
 }
 
-response = Device.search(api = client, params = params)
+# Use data=... to send also a JSON body in the request
+response = Device.search(api=client, data=params)
+
 if len(response) > 0:
-    print("\nDevice Details :")
+    print("Devices Details:\n")
     for device in response:
-        print("Device name: %s Device Id: %s Device Visibility: %s Device Status: %s " % (device.name, device.id, device.visibility, device.status ))
+        print("          Name: {device.name}".format(device=device))
+        print("            Id: {device.id}".format(device=device))
+        print("    Visibility: {device.visibility}".format(device=device))
+        print("        Status: {device.status}\n".format(device=device))
 else:
     print("Devices not available in this search criteria")
- 

--- a/m2x/api.py
+++ b/m2x/api.py
@@ -134,7 +134,7 @@ class HTTPAPIBase(APIBase):
             kwargs.setdefault('headers', {})
             kwargs['headers']['X-M2X-KEY'] = apikey
 
-        if method in ('PUT', 'POST', 'DELETE', 'PATCH') and kwargs.get('data'):
+        if kwargs.get('data'):
             kwargs['data'] = self.to_json(kwargs['data'])
 
         resp = self.session.request(method, url, **kwargs)

--- a/m2x/tests/test_utils.py
+++ b/m2x/tests/test_utils.py
@@ -9,7 +9,7 @@ class TestUtils(object):
     def test_to_utc(self):
         dtime = datetime.now()
         utc_dtime = utils.to_utc(dtime)
-        assert isinstance(utc_dtime.tzinfo, iso8601.Utc)
+        assert utc_dtime.tzinfo == iso8601.UTC
 
     def test_to_iso(self):
         dtime = iso8601.parse_date('2015-04-15 12:00:00+0300')
@@ -39,7 +39,7 @@ class TestUtils(object):
         out = utils.from_server('timestamp', '2015-04-15T15:00:00.000000Z')
         assert out.year == 2015 and out.month == 4 and out.day == 15
         assert out.hour == 15 and out.minute == 0 and out.second == 0
-        assert isinstance(out.tzinfo, iso8601.Utc)
+        assert out.tzinfo == iso8601.UTC
         out = utils.from_server('ignored', 'just a string')
         assert out == 'just a string'
         out = utils.from_server('ignored', 123)

--- a/m2x/tests/v2/test_distributions.py
+++ b/m2x/tests/v2/test_distributions.py
@@ -32,5 +32,5 @@ class TestDistributions(BaseTestCase):
 
     @BaseTestCase.request_case
     def test_add_device(self, params=None, **kwargs):
-        out = self.distribution.add_device(**params)
+        out = self.distribution.add_device(params)
         assert out.name == 'device3'

--- a/m2x/v2/devices.py
+++ b/m2x/v2/devices.py
@@ -265,5 +265,5 @@ class Device(Resource, Metadata):
 
     @classmethod
     def search(cls, api, **params):
-        response = api.post('devices/search', **params)
+        response = api.get('devices/search', **params)
         return cls.itemize(api, response)

--- a/pyenv_tox.sh
+++ b/pyenv_tox.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 which pyenv && eval "$(pyenv init -)"
 tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py27, py34, py35, py36
 
 [testenv]
 commands = py.test m2x/tests


### PR DESCRIPTION
This PR updates the usage of the search devices endpoint to use the `GET` method and support sending a `JSON` body content if it was specified.